### PR TITLE
Update splice documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,8 +236,11 @@ Obviously this will fail if the value at cursor is not an array.
 ```js
 var newArray = cursor.splice([1, 1]);
 
-// Applying splice n times with different arguments
-var newArray = cursor.splice([[1, 2], [3, 2, 'hello']]);
+// Inserting an item
+var newArray = cursor.splice([1, 0, 'newItem']);
+
+// Inserting multiple items
+var newArray = cursor.splice([1, 0, 'newItem1', 'newItem2']);
 
 // At key
 var newArray = cursor.splice('list', [1, 1])


### PR DESCRIPTION
I found it difficult to figure out how to insert 1 or more items using splice and so added examples for that.  I also removed the docs about applying splice n times because when I tried to test that functionality it threw `Baobab.Cursor.splice: invalid value.` (and I could find no tests covering it).
